### PR TITLE
Deny iFrame embeds

### DIFF
--- a/static/__header
+++ b/static/__header
@@ -1,0 +1,2 @@
+/*
+  X-Frame-Options: DENY


### PR DESCRIPTION
This adds the X-Frame-Options: DENY header to every page hosted on Netlify

Reference:
https://docs.netlify.com/routing/headers/#syntax-for-the-headers-file

Also note:
`hugo` creates the `public` directory which automatically contains all resources from `static`. Netlify has the `public` directory configure as the deployment directory. This is where it expects the `__header` file.