### PR TITLE
add link to dapr China community website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -68,6 +68,11 @@ name = "Discord"
 URL = "https://aka.ms/dapr-discord"
 weight = 6
 
+[[menu.main]]
+name = "中国社区"
+URL = "https://cn.dapr.io"
+weight = 7
+
 # footer menu left
 [[menu.footer_left]]
 name = "How to contribute"
@@ -106,6 +111,10 @@ name = "Twitter"
 URL = "https://twitter.com/daprdev"
 weight = 3
 
+[[menu.footer_right]]
+name = "中国社区"
+URL = "https://cn.dapr.io"
+weight = 4
 
 #################### default parameters ################################
 [params]


### PR DESCRIPTION
Signed-off-by: Sky Ao <aoxiaojian@gmail.com>

This PR will add a link to china community website in top navigator:

<img width="1206" alt="Screen Shot 2022-07-20 at 17 23 33" src="https://user-images.githubusercontent.com/1582369/179947378-61167264-b2cf-44be-b9e2-90039930cf25.png">

And in the footer:

<img width="1328" alt="Screen Shot 2022-07-20 at 17 23 43" src="https://user-images.githubusercontent.com/1582369/179947406-5a380562-9362-4bea-ba16-46c439d69ee6.png">

