### PR TITLE
Add lightweight analytics pixel to dapr website

### DIFF
--- a/themes/bigspring/layouts/partials/footer.html
+++ b/themes/bigspring/layouts/partials/footer.html
@@ -50,6 +50,7 @@
       <small class="content">{{ site.Params.Trademark | markdownify }}</small>
     </div>
   </div>
+  <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4848fb3b-3edb-4329-90a9-a9d79afff054" />
 </footer>
 
 {{ "<!-- JS Plugins -->" | safeHTML }}


### PR DESCRIPTION
This analytics pixel provides high-level web traffic insights for project maintainers so they can better understand how the dapr website is being used. This pixel does not use cookies (or JavaScript at all) and is GDPR-compliant. It is a clear 1x1 pixel that won't affect page rendering or load times.

Signed-off-by: Arjun Devarajan <arjun@scarf.sh>