### PR TITLE
Redirect dapr.io/enc/v1 to crypto scheme docs

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/enc/v1		https://github.com/dapr/kit/blob/main/schemes/enc/v1/README.md	301	true


### PR DESCRIPTION
Each file encrypted with the Dapr crypto scheme begins with `dapr.io/enc/v1`, which is used to identify the file type. It's common pattern to make sure that the string corresponds to a real URL that points to the specs of the scheme used.

This creates a redirect so `http://dapr.io/enc/v1` points to https://github.com/dapr/kit/blob/main/schemes/enc/v1/README.md

The link above isn't currently working because the PR hasn't been fully merged, but this is what it will look like once it's merged: https://github.com/dapr/kit/blob/854be34d47663dd3cf80ebdee69d91195dc8d76a/schemes/enc/v1/README.md

> This works by using the `_redirects` file that Netlify understands: https://docs.netlify.com/routing/redirects/