### PR TITLE
Add holopin.yaml for website badge

### DIFF
--- a/.github/holopin.yaml
+++ b/.github/holopin.yaml
@@ -1,0 +1,6 @@
+organization: dapr
+defaultSticker: clrqffunr242860gjxng34gcru
+stickers:
+  -
+    id: clrqffunr242860gjxng34gcru
+    alias: website-badge


### PR DESCRIPTION
# Desciption
Add `holopin.yaml` config for the website badge.

# Issue
#92 

