### PR TITLE
Remove onlick handlers to fix broken nav on macOS

### DIFF
--- a/themes/bigspring/layouts/enterprise/list.html
+++ b/themes/bigspring/layouts/enterprise/list.html
@@ -56,7 +56,7 @@
         {{with .content }}<p class="mb-4">{{ . | markdownify }}</p>{{ end }}
         {{ if .button.enable }}
         {{ with .button }}
-        <a href="{{ .link | absURL }}" onclick="captureOutboundLink('{{ .link | absURL }}'); return false;"
+        <a href="{{ .link | absURL }}" 
           class="btn btn-primary stretched-link"><button class="btn-primary btn-md">{{ .label }}</button></a>
         {{ end }}
         {{ end }}

--- a/themes/bigspring/layouts/partials/footer.html
+++ b/themes/bigspring/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     <ul class="list-style-none">
       <li class="text-bold padding-bottom-20">{{ site.Params.footer_menu_column1 }}</li>
       {{ range site.Menus.footer_column1 }}
-      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" onclick="captureOutboundLink('{{ .URL | absURL }}'); return false;" class="navLink">{{ .Name }}</a></li>
+      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" class="navLink">{{ .Name }}</a></li>
       {{ end }}
     </ul>
     {{ end }}
@@ -13,7 +13,7 @@
     <ul class="list-style-none">
       <li class="text-bold padding-bottom-20">{{ site.Params.footer_menu_column2 }}</li>
       {{ range site.Menus.footer_column2 }}
-      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" onclick="captureOutboundLink('{{ .URL | absURL }}'); return false;" class="navLink">{{ .Name }}</a></li>
+      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" class="navLink">{{ .Name }}</a></li>
       {{ end }}
     </ul>
     {{ end }}  
@@ -22,7 +22,7 @@
     <ul class="list-style-none">
       <li class="text-bold padding-bottom-20">{{ site.Params.footer_menu_column3 }}</li>
       {{ range site.Menus.footer_column3 }}
-      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" onclick="captureOutboundLink('{{ .URL | absURL }}'); return false;" class="navLink">{{ .Name }}</a></li>
+      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" class="navLink">{{ .Name }}</a></li>
       {{ end }}
     </ul>
     {{ end }}
@@ -31,7 +31,7 @@
     <ul class="list-style-none">
       <li class="text-bold padding-bottom-20">{{ site.Params.footer_menu_column4 }}</li>
       {{ range site.Menus.footer_column4 }}
-      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" onclick="captureOutboundLink('{{ .URL | absURL }}'); return false;" class="navLink">{{ .Name }}</a></li>
+      <li class="padding-bottom-10"><a href="{{ .URL | absURL }}" class="navLink">{{ .Name }}</a></li>
       {{ end }}
     </ul>
     {{ end }}  

--- a/themes/bigspring/layouts/partials/footer.html
+++ b/themes/bigspring/layouts/partials/footer.html
@@ -55,15 +55,6 @@
 {{ "<!-- Main Script -->" | safeHTML }}
 {{ $script := resources.Get "js/script.js" | minify}}
 <script src="{{ $script.Permalink }}"></script>
-<script src="{{ $script.Permalink }}"></script>
-<script>
-  var captureOutboundLink = function (url) {
-    ga('send', 'event', 'outbound', 'click', url, {
-      'transport': 'beacon',
-      'hitCallback': function () { document.location = url; }
-    });
-  }
-</script>
 <script
 src="https://kit.fontawesome.com/91dde3bebe.js"
 crossorigin="anonymous"

--- a/themes/bigspring/layouts/partials/header.html
+++ b/themes/bigspring/layouts/partials/header.html
@@ -21,7 +21,7 @@
             <div class="navbar-dropdown" role="menu">
               <div class="flex flex-column">
                 {{ range .Children }}
-                <a href="{{ .URL | absURL }}" onclick="captureOutboundLink('{{ .URL | absURL }}'); return false;" class="navLink navbar-item">{{ .Name }}</a>
+                <a href="{{ .URL | absURL }}" class="navLink navbar-item">{{ .Name }}</a>
                 {{ end }}
               </div>
             </div>

--- a/themes/bigspring/layouts/pricing/list.html
+++ b/themes/bigspring/layouts/pricing/list.html
@@ -18,7 +18,7 @@
             </ul>
             {{ if .button.enable }}
             {{ with .button }}
-            <a href="{{ .link | absURL }}" onclick="captureOutboundLink('{{ .link | absURL }}'); return false;" class="btn btn-outline-primary">{{ .label }}</a>
+            <a href="{{ .link | absURL }}" class="btn btn-outline-primary">{{ .label }}</a>
             {{ end }}
             {{ end }}
           </div>
@@ -39,7 +39,7 @@
             </ul>
             {{ if .button.enable }}
             {{ with .button }}
-            <a href="{{ .link | absURL }}" onclick="captureOutboundLink('{{ .link | absURL }}'); return false;" class="btn btn-primary">{{ .label }}</a>
+            <a href="{{ .link | absURL }}" class="btn btn-primary">{{ .label }}</a>
             {{ end }}
             {{ end }}
           </div>
@@ -60,7 +60,7 @@
             </ul>
             {{ if .button.enable }}
             {{ with .button }}
-            <a href="{{ .link | absURL }}" onclick="captureOutboundLink('{{ .link | absURL }}'); return false;" class="btn btn-outline-primary">{{ .label }}</a>
+            <a href="{{ .link | absURL }}" class="btn btn-outline-primary">{{ .label }}</a>
             {{ end }}
             {{ end }}
           </div>
@@ -85,7 +85,7 @@
         {{with .content }}<p class="mb-4">{{ . | markdownify }}</p>{{ end }}
         {{ if .button.enable }}
         {{ with .button }}
-        <a href="{{ .link | absURL }}" onclick="captureOutboundLink('{{ .link | absURL }}'); return false;" class="btn btn-primary">{{ .label }}</a>
+        <a href="{{ .link | absURL }}" class="btn btn-primary">{{ .label }}</a>
         {{ end }}
         {{ end }}
       </div>

--- a/themes/bigspring/layouts/testimonials/list.html
+++ b/themes/bigspring/layouts/testimonials/list.html
@@ -53,7 +53,7 @@
         {{with .content }}<p class="mb-4">{{ . | markdownify }}</p>{{ end }}
         {{ if .button.enable }}
         {{ with .button }}
-        <a href="{{ .link | absURL }}" onclick="captureOutboundLink('{{ .link | absURL }}'); return false;" class="btn btn-primary stretched-link"><button class="btn-primary btn-md">{{ .label }}</button></a>
+        <a href="{{ .link | absURL }}" class="btn btn-primary stretched-link"><button class="btn-primary btn-md">{{ .label }}</button></a>
         {{ end }}
         {{ end }}
       </div>


### PR DESCRIPTION
Remove onclick events to ensure these event do not break the navigation on macOS.

Fixes issue #100

As mentioned in the issue, this handling of events is outdated since GA4 is now being used.