### PR TITLE
feat: add the Scarf analytics pixel to dapr.io

### DIFF
--- a/themes/bigspring/layouts/partials/footer.html
+++ b/themes/bigspring/layouts/partials/footer.html
@@ -139,6 +139,9 @@ const handleToggle = () => {
         if (typeof window.daprInjectReo === "function") {
           window.daprInjectReo();
         }
+        if (typeof window.daprInjectScarf === "function") {
+          window.daprInjectScarf();
+        }
       });
     }
 

--- a/themes/bigspring/layouts/partials/head.html
+++ b/themes/bigspring/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
   <meta charset="utf-8">
-  {{ "<!-- Reo analytics (loaded only with cookie consent) -->" | safeHTML }}
+  {{ "<!-- Reo + Scarf analytics (loaded only with cookie consent) -->" | safeHTML }}
   <script>
   (function () {
     var COOKIE_NAME = "dapr_cookie_consent";
@@ -29,8 +29,23 @@
       document.head.appendChild(s);
     };
 
+    // Scarf pixel. docs.dapr.io already carries one; the website did not, so
+    // referral traffic to dapr.io was invisible to the project. Requests a 1x1
+    // image, which Scarf resolves to coarse company/location data. No cookies
+    // are set and no identifiers are stored by the pixel itself.
+    var scarfInjected = false;
+    window.daprInjectScarf = function () {
+      if (scarfInjected) { return; }
+      scarfInjected = true;
+      var pixelId = "0f63416a-15c2-4ccd-bae0-001898f75f8f";
+      var pixel = new Image();
+      pixel.referrerPolicy = "no-referrer-when-downgrade";
+      pixel.src = "https://static.scarf.sh/a.png?x-pxid=" + pixelId;
+    };
+
     if (readConsent() === "accepted") {
       window.daprInjectReo();
+      window.daprInjectScarf();
     }
   })();
   </script>


### PR DESCRIPTION
# Description

Adds a Scarf analytics pixel to dapr.io.

docs.dapr.io has carried one since July, but the website never had one, so traffic to dapr.io itself was invisible to the project. Scarf.sh is listed as a community-managed analytics tool in [COMMUNITY-MANAGER.md](https://github.com/dapr/community/blob/master/COMMUNITY-MANAGER.md), and is one of the analytics services CNCF makes available to its projects ([CNCF hosted tools](https://contribute.cncf.io/resources/project-services/hosted-tools/)).

**How it works:** the pixel is injected the same way Reo already is — defined in `head.html`, and loaded only once the visitor has accepted analytics cookies. It fires on page load if consent is already stored, and the consent banner triggers it on Accept. Choosing Reject means it never loads. Requesting the image sets no cookies of its own.

Reo is unchanged. This is additive: +19/−1, and the single removed line is the comment header updating from "Reo analytics" to "Reo + Scarf analytics".
